### PR TITLE
Support for writeHead method

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,17 @@
 // Mocks http.ServerResponse
 
+
 module.exports = MockServerResponse;
 
 var Transform = require('stream').Transform,
-	util = require('util');
+	util = require('util'),
+	STATUS_CODES = require('http').STATUS_CODES;
 
 function MockServerResponse(finish) {
 	Transform.call(this);
 
 	this.statusCode = 200;
+	this.statusMessage = STATUS_CODES[this.statusCode];
 
 	this._headers = {};
 	if (typeof finish === 'function')
@@ -34,6 +37,20 @@ MockServerResponse.prototype.removeHeader = function(name) {
 	delete this._headers[name.toLowerCase()];
 };
 
+MockServerResponse.prototype.writeHead = function(statusCode, reason, headers) {
+	if (arguments.length == 2 && typeof arguments[1] !== 'string') {
+		headers = reason;
+		reason = undefined;
+	}
+	this.statusCode = statusCode;
+	this.statusMessage = reason || STATUS_CODES[statusCode] || 'unknown';
+	if (headers) {
+		for (var name in headers) {
+			this.setHeader(name, headers[name]);
+		}
+	}
+};
+
 MockServerResponse.prototype._getString = function() {
 	return Buffer.concat(this._readableState.buffer).toString();
 };
@@ -44,7 +61,6 @@ MockServerResponse.prototype._getJSON = function() {
 
 /* Not implemented:
 MockServerResponse.prototype.writeContinue()
-MockServerResponse.prototype.writeHead(statusCode, [reasonPhrase], [headers])
 MockServerResponse.prototype.setTimeout(msecs, callback)
 MockServerResponse.prototype.headersSent
 MockServerResponse.prototype.sendDate

--- a/test.js
+++ b/test.js
@@ -1,4 +1,5 @@
 var assert = require('assert'),
+	STATUS_CODES = require('http').STATUS_CODES,
 	MockResponse = require('./index');
 
 var tests = [
@@ -40,6 +41,70 @@ var tests = [
 
 		res.removeHeader('Type'); // case sensitive???
 		assert(!res.getHeader('type'));
+
+		done();
+	},
+
+	function can_write_head(done) {
+		var res = new MockResponse();
+
+		res.writeHead(401);
+
+		assert.equal(res.statusCode, 401);
+		assert.equal(res.statusMessage, STATUS_CODES['401']);
+
+		done();
+	},
+
+	function can_write_head_with_reason(done) {
+		var res = new MockResponse();
+
+		res.writeHead(401, 'Disauthorized');
+
+		assert.equal(res.statusCode, 401);
+		assert.equal(res.statusMessage, 'Disauthorized');
+
+		done();
+	},
+
+	function can_write_head_with_headers(done) {
+		var res = new MockResponse();
+
+		res.writeHead(404, {Type: 'x', foo: 'bar'});
+
+		assert.equal(res.getHeader('Type'), 'x');
+		assert.equal(res.getHeader('type'), 'x');
+		assert.equal(res.getHeader('foo'), 'bar');
+		assert.equal(res.getHeader('FOO'), 'bar');
+
+		assert.equal(res.statusCode, 404);
+		assert.equal(res.statusMessage, STATUS_CODES['404']);
+
+		done();
+	},
+
+	function can_write_head_with_reason_and_headers(done) {
+		var res = new MockResponse();
+
+		res.writeHead(500, 'something failed', {Type: 'x'});
+
+		assert.equal(res.getHeader('type'), 'x');
+
+		assert.equal(res.statusCode, 500);
+		assert.equal(res.statusMessage, 'something failed');
+
+		done();
+	},
+
+	function can_write_head_unknown_code(done) {
+		var res = new MockResponse();
+
+		res.writeHead(299, {Type: 'x'});
+
+		assert.equal(res.getHeader('type'), 'x');
+
+		assert.equal(res.statusCode, 299);
+		assert.equal(res.statusMessage, 'unknown');
 
 		done();
 	},


### PR DESCRIPTION
This adds `res.writeHead(code, reason, headers)` support, handling both optional reason and headers.  It does not support the deprecated array form for headers.  The response `statusMessage` is set when the `statusCode` is set.  Values come from the `http.STATUS_CODES` lookup and can be customized by providing a reason argument to `res.writeHead()`.
