### PR TITLE
Document the writeHead method

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,5 +78,6 @@ See `test.js` for further usage.
 ## Methods
 
 * All readable/writable stream methods.
+* `writeHead(statusCode, [reasonPhrase], [headers])` Sets the response status code, status message, and headers.  See also the [`http.ServerResponse` documentation](http://nodejs.org/api/http.html#http_response_writehead_statuscode_reasonphrase_headers).
 * `_getString()` Reads the body as a string, from the internal stream buffer.
 * `_getJSON()` Reads the body as a parsed JSON object, from the internal stream buffer.


### PR DESCRIPTION
This documents the new `writeHead` method.  See https://github.com/diachedelic/mock-res/pull/1#issuecomment-49538281.
