### PR TITLE
To define extra property res._header for Morgan to log status code for

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ results
 
 npm-debug.log
 node_modules
+/.project

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ function MockServerResponse(finish) {
 	this.statusCode = 200;
 	this.statusMessage = STATUS_CODES[this.statusCode];
 
-	this._headers = {};
+	this._header = this._headers = {};
 	if (typeof finish === 'function')
 		this.on('finish', finish);
 }


### PR DESCRIPTION
The following is Morgan output with "_header" defined. Response time can also be shown with minor change in Morgan. It seems that "content-length" cannot be provided in websocket req.
Please review.

GET /api/user?limit=10&skip=0 200 1742.797 ms - -
GET /api/roster?limit=10&skip=0 200 1808.194 ms - -
PUT /api/user/me 200 1801.649 ms - -
GET /im.app/lib/ionic/fonts/ionicons.ttf?v=2.0.1 304 1.313 ms - -
GET /im.app/templates/user/status.html 304 2.037 ms -