### PR TITLE
Fix: Don't rely on shape of `_readableState`

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,12 +16,15 @@ function MockServerResponse(finish) {
 	this._header = this._headers = {};
 	if (typeof finish === 'function')
 		this.on('finish', finish);
+
+	this._responseData = []
 }
 
 util.inherits(MockServerResponse, Transform);
 
 MockServerResponse.prototype._transform = function(chunk, encoding, next) {
 	this.push(chunk);
+	this._responseData.push(chunk)
 	next();
 };
 
@@ -52,7 +55,7 @@ MockServerResponse.prototype.writeHead = function(statusCode, reason, headers) {
 };
 
 MockServerResponse.prototype._getString = function() {
-	return Buffer.concat(this._readableState.buffer).toString();
+	return Buffer.concat(this._responseData);
 };
 
 MockServerResponse.prototype._getJSON = function() {


### PR DESCRIPTION
The previous code relies on the shape of the private property `_readableState` which caused it to break for more recent versions of Node.js. This patch changes the implementation to use the public, documented interface only.

Fixes #5.