### PR TITLE
Fix various issues with the implementation of res.finished

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,8 @@ function MockServerResponse(finish) {
 		this.on('finish', finish);
 
 	this._responseData = []
+
+	this.finished = false;
 }
 
 util.inherits(MockServerResponse, Transform);
@@ -62,11 +64,10 @@ MockServerResponse.prototype._getJSON = function() {
 	return JSON.parse(this._getString());
 };
 
-Object.defineProperty(MockServerResponse.prototype, 'finished', {
-    get: function() {
-        return this._writableState.finished;
-    }
-});
+MockServerResponse.prototype.end = function() {
+	Transform.prototype.end.apply(this, arguments);
+	this.finished = true;
+}
 
 /* Not implemented:
 MockServerResponse.prototype.writeContinue()

--- a/test.js
+++ b/test.js
@@ -189,22 +189,17 @@ var tests = [
 		src.pipe(res);
 	},
 
-	function sets_finished_after_pipe(done) {
+	function sets_finished_after_end_called(done) {
 		var res = new MockResponse();
-		var src = fs.createReadStream(__filename);
-
-		res.on('finish', function() {
-			assert.strictEqual(res.finished, true);
-			done();
-		});
-
-		res.on('error', assert.fail);
 
 		assert.strictEqual(res.finished, false);
 
-		src.pipe(res);
-	},
+		res.setHeader('Location', 'http://example.com');
+		res.statusCode = 302;
+		res.end();
 
+		assert.strictEqual(res.finished, true);
+	},
 ];
 
 var doneCount = 0;


### PR DESCRIPTION
When using mock-res 0.4.0 in my project, I found an issue with my implementation of res.finished.

The problem was that res.finished needs to be true instantly after res.end() executes (see https://nodejs.org/api/http.html#http_response_finished). With the current implementation, it isn't true instantly after res.end() is called, but only after all data has been written.

So this PR fixes that and by doing so also resigns from using private APIs.