### PR TITLE
Add missing res.getHeaders()

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,6 +38,10 @@ MockServerResponse.prototype.getHeader = function(name) {
 	return this._headers[name.toLowerCase()];
 };
 
+MockServerResponse.prototype.getHeaders = function() {
+	return this._headers;
+};
+
 MockServerResponse.prototype.removeHeader = function(name) {
 	delete this._headers[name.toLowerCase()];
 };

--- a/test.js
+++ b/test.js
@@ -39,9 +39,11 @@ var tests = [
 		res.setHeader('Type', 'x');
 		assert.equal(res.getHeader('Type'), 'x');
 		assert.equal(res.getHeader('type'), 'x'); // case insensitive
+		assert.deepEqual(res.getHeaders(), { type: 'x' });
 
 		res.removeHeader('Type'); // case sensitive???
 		assert(!res.getHeader('type'));
+		assert.deepEqual(res.getHeaders(), {});
 
 		done();
 	},


### PR DESCRIPTION
[res.getHeaders](https://nodejs.org/api/http.html#http_response_getheaders), which nodejs offers, is missing.

This PR adds that method.