### PR TITLE
Add option to specify body encoding

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,8 +60,8 @@ MockServerResponse.prototype.writeHead = function(statusCode, reason, headers) {
 	}
 };
 
-MockServerResponse.prototype._getString = function() {
-	return Buffer.concat(this._responseData).toString();
+MockServerResponse.prototype._getString = function(encoding) {
+	return Buffer.concat(this._responseData).toString(encoding || 'utf8');
 };
 
 MockServerResponse.prototype._getJSON = function() {


### PR DESCRIPTION
Use case: handling gzip compressed body.

```ts
const useBase64 = Boolean(res.getHeader('content-encoding'));
const body = res._getString(useBase64 ? 'base64' : 'utf8');
if (useBase64) ...
```

Ref: https://nodejs.org/api/buffer.html#buffer_buf_tostring_encoding_start_end
